### PR TITLE
Fix 'commentstring' value

### DIFF
--- a/ftplugin/sml.vim
+++ b/ftplugin/sml.vim
@@ -43,3 +43,5 @@ else
 endif
 
 cnoreabbrev make make!
+
+setlocal commentstring=(*%s*)


### PR DESCRIPTION
When the correct `commentstring` value is set plug-ins like [Commentary](https://github.com/tpope/vim-commentary) and [TComment](https://github.com/tomtom/tcomment_vim) do The Right Thing™